### PR TITLE
Github: Added IssueLabelType and additional fields to IssueType

### DIFF
--- a/graphqlhub-schemas/src/github.js
+++ b/graphqlhub-schemas/src/github.js
@@ -5,7 +5,6 @@ import {
   getRepoForUser,
   getIssuesForRepo,
   getCommentsForIssue,
-  getLabelsForIssue,
 } from './apis/github';
 
 import {

--- a/graphqlhub-schemas/src/github.js
+++ b/graphqlhub-schemas/src/github.js
@@ -5,6 +5,7 @@ import {
   getRepoForUser,
   getIssuesForRepo,
   getCommentsForIssue,
+  getLabelsForIssue,
 } from './apis/github';
 
 import {
@@ -91,6 +92,15 @@ let IssueCommentType = new GraphQLObjectType({
   },
 });
 
+let IssueLabelType = new GraphQLObjectType({
+  name : 'GithuIssueLabelType',
+  fields: {
+    url : { type : GraphQLString },
+    name : { type : GraphQLString },
+    color: { type : GraphQLString }
+  }
+});
+
 let grabUsernameAndReponameFromURL = (url) => {
   let array = url.split('/repos/')[1].split('/issues')[0].split('/');
   return {
@@ -103,8 +113,13 @@ let IssueType = new GraphQLObjectType({
   name : 'GithubIssue',
   fields : {
     id : { type : GraphQLInt },
+    state: { type : GraphQLString },
     title : { type : GraphQLString },
     body : { type : GraphQLString },
+    user : { type : UserType },
+    assignee : { type : UserType },
+    closed_by : { type : UserType },
+    labels : { type : new GraphQLList(IssueLabelType) },
     commentCount : {
       type : GraphQLInt,
       resolve(issue) {


### PR DESCRIPTION
Noticed that all retrieved issues were {'state': 'open'}. Not sure if this is because of github-api or if additional query parameters are required to retrieve issues with different states.
