### PR TITLE
bump giphy-api and twit

### DIFF
--- a/graphqlhub-schemas/package.json
+++ b/graphqlhub-schemas/package.json
@@ -18,12 +18,12 @@
   "author": "Clay Allsopp <clay.allsopp@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "giphy-api": "1.1.14",
+    "giphy-api": "^1.2.1",
     "github-api": "https://github.com/clayallsopp/github/tarball/fork",
     "graphql-relay": "0.3.6",
     "lodash": "3.10.1",
     "node-fetch": "1.3.2",
-    "twit": "2.1.1"
+    "twit": "^2.2.5"
   },
   "peerDependencies": {
     "graphql": "~0.4.2"


### PR DESCRIPTION
Bithound shows warnings about oudated, unsecure dependencies, e.g. twitter and giphy client.
Upgrading to new version still works.