### PR TITLE
Add Deploy to Heroku button in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
   <img src="public/images/graphqlhub-logo.png" alt="GraphQLHub Logo" width="305" height="300"/>
 </p>
 
+[![Deploy your own GraphQLHub](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
+Set the API key values in the deploying page under config variables. Only Twitter and Giphy API keys are required, others are optional.
+
 # GraphQLHub Schemas
 
 Want to install the various GraphQLHub schemas and use on your own? See [graphqlhub-schemas](./graphqlhub-schemas) for details.
@@ -57,5 +61,3 @@ Then visit [http://localhost:3000](http://localhost:3000) in your browser.
 - Use GraphiQL from NPM, not the vendoring thing done now
 
 PRs for anything above would be excellent!
-
-

--- a/app.json
+++ b/app.json
@@ -1,0 +1,36 @@
+{
+  "name": "graphqlhub",
+  "description": "GraphQLHub.com",
+  "repository": "https://github.com/clayallsopp/graphqlhub",
+  "keywords": ["graphqlhub", "graphql"],
+  "env": {
+    "GITHUB_TOKEN": {
+      "description": "Optional Key. Github personal token obtained from https://github.com/settings/tokens",
+      "value": "",
+      "required": false
+    },
+    "TWITTER_CONSUMER_KEY": {
+      "description": "Twitter consumer key obtained from https://apps.twitter.com/",
+      "value": ""
+    },
+    "TWITTER_CONSUMER_SECRET": {
+      "description": "Twitter consumer key obtained from https://apps.twitter.com/",
+      "value": ""
+    },
+    "GIPHY_API_KEY": {
+      "description": "Below key is public key. Giphy personal API key can be obtained by submitting form in http://api.giphy.com/submit",
+      "value": "dc6zaTOxFJmzC",
+      "required": true
+    },
+    "KEEN_PROJECT_ID": {
+      "description": "Key obtained from https://keen.io/",
+      "value": "",
+      "required": false
+    },
+    "KEEN_WRITE_KEY": {
+      "description": "Key obtained from https://keen.io/",
+      "value": "",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
Hey @clayallsopp !
I added a Deploy to Heroku button. This should help other devs easily deploy their own GraphQLHub server for educational purposes